### PR TITLE
Case insensitivity

### DIFF
--- a/deft_app/filenames.py
+++ b/deft_app/filenames.py
@@ -35,3 +35,25 @@ def escape_filename(filename):
     escape character. It is also an escape character for itself.
     """
     return ''.join([_escape(char) for char in filename])
+
+
+def unescape_filename(filename):
+    """Inverse of escape_filename"""
+    unescape_map = {value: key for key, value in _escape_map.items()}
+    escape = False
+    output = []
+    for char in filename:
+        if escape:
+            if char in unescape_map:
+                output.append(unescape_map[char])
+            else:
+                output.append(char.lower())
+            escape = False
+        elif char == '_':
+            escape = True
+        elif char in _escape_map:
+            raise ValueError(f'Filename {filename} contains invalid'
+                             ' characters')
+        else:
+            output.append(char)
+    return ''.join(output)

--- a/deft_app/filenames.py
+++ b/deft_app/filenames.py
@@ -5,26 +5,33 @@ which is broken in a case insensitive file system.
 """
 
 
+_escape_map = {'/': '0',
+               '\\': '1',
+               '?': '2',
+               '%': '3',
+               '*': '4',
+               ':': '5',
+               '|': '6',
+               '"': '7',
+               '<': '8',
+               '>': '9',
+               '.': ',',
+               '_': '_'}
+
+
+def _escape(char):
+    if char in _escape_map:
+        return '_' + _escape_map[char]
+    elif char.islower():
+        return '_' + char.upper()
+    else:
+        return char
+
+
 def escape_lower_case(file_name):
     """Convert filename for one with escape character before lowercase
 
     This is done to handle case insensitive file systems. _ is used as an
     escape character. It is also an escape character for itself.
     """
-    return ''.join(['_' + char.upper() if char.islower()
-                    or char == '_' else char for char in file_name])
-
-
-def unescape_lower_case(file_name):
-    """Inverse of previous function."""
-    underscore = False
-    output = []
-    for char in file_name:
-        if underscore:
-            output.append(char.lower())
-            underscore = False
-        elif char == '_':
-            underscore = True
-        else:
-            output.append(char)
-    return ''.join(output)
+    return ''.join([_escape(char) for char in file_name])

--- a/deft_app/filenames.py
+++ b/deft_app/filenames.py
@@ -28,10 +28,10 @@ def _escape(char):
         return char
 
 
-def escape_lower_case(file_name):
+def escape_filename(filename):
     """Convert filename for one with escape character before lowercase
 
     This is done to handle case insensitive file systems. _ is used as an
     escape character. It is also an escape character for itself.
     """
-    return ''.join([_escape(char) for char in file_name])
+    return ''.join([_escape(char) for char in filename])

--- a/deft_app/filenames.py
+++ b/deft_app/filenames.py
@@ -1,0 +1,30 @@
+"""These functions are used to escape and unescape lower case characters
+filenames to make the deft_app compatible with case insensitive file systems.
+The Deft app design involves using filenames as keys in an implicit database,
+which is broken in a case insensitive file system.
+"""
+
+
+def escape_lower_case(file_name):
+    """Convert filename for one with escape character before lowercase
+
+    This is done to handle case insensitive file systems. _ is used as an
+    escape character. It is also an escape character for itself.
+    """
+    return ''.join(['_' + char.upper() if char.islower()
+                    or char == '_' else char for char in file_name])
+
+
+def unescape_lower_case(file_name):
+    """Inverse of previous function."""
+    underscore = False
+    output = []
+    for char in file_name:
+        if underscore:
+            output.append(char.lower())
+            underscore = False
+        elif char == '_':
+            underscore = True
+        else:
+            output.append(char)
+    return ''.join(output)

--- a/deft_app/filenames.py
+++ b/deft_app/filenames.py
@@ -4,25 +4,14 @@ The Deft app design involves using filenames as keys in an implicit database,
 which is broken in a case insensitive file system.
 """
 
-
-_escape_map = {'/': '0',
-               '\\': '1',
-               '?': '2',
-               '%': '3',
-               '*': '4',
-               ':': '5',
-               '|': '6',
-               '"': '7',
-               '<': '8',
-               '>': '9',
-               '.': ',',
-               '_': '_'}
+_escape_map = {'_': '_',
+               '/': 's'}
 
 
 def _escape(char):
     if char in _escape_map:
         return '_' + _escape_map[char]
-    elif char.islower():
+    if char.islower():
         return '_' + char.upper()
     else:
         return char

--- a/deft_app/fix.py
+++ b/deft_app/fix.py
@@ -9,7 +9,7 @@ from flask import Blueprint, request, render_template, session
 from deft.modeling.classify import load_model
 
 from .locations import DATA_PATH
-from .filenames import escape_lower_case
+from .filenames import escape_filename
 from .scripts.consistency import (check_grounding_dict,
                                   check_model_consistency,
                                   check_names_consistency)
@@ -25,7 +25,7 @@ def initialize():
     model_name = request.form['modelname']
     if not model_name:
         return render_template('index.jinja2')
-    model_name = escape_lower_case(model_name)
+    model_name = escape_filename(model_name)
     models_path = os.path.join(DATA_PATH, 'models', model_name)
     with open(os.path.join(models_path,
                            model_name + '_grounding_dict.json')) as f:
@@ -35,7 +35,7 @@ def initialize():
     longforms = defaultdict(list)
     longform_scores = defaultdict(int)
     for shortform, grounding_map in grounding_dict.items():
-        cased_shortform = escape_lower_case(shortform)
+        cased_shortform = escape_filename(shortform)
         with open(os.path.join(DATA_PATH, 'longforms',
                                f'{cased_shortform}_longforms.json'), 'r') as f:
             lf_scores = json.load(f)
@@ -162,7 +162,7 @@ def submit():
     names_dict = {}
     pos_labels_dict = {}
     for shortform, grounding_map in new_grounding_dict.items():
-        cased_shortform = escape_lower_case(shortform)
+        cased_shortform = escape_filename(shortform)
         with open(os.path.join(groundings_path, shortform,
                                f'{cased_shortform}_names.json'), 'r') as f:
             temp = json.load(f)
@@ -184,7 +184,7 @@ def submit():
 
     # update groundings files used for training model
     for shortform, grounding_map in new_grounding_dict.items():
-        cased_shortform = escape_lower_case(shortform)
+        cased_shortform = escape_filename(shortform)
         with open(os.path.join(groundings_path, shortform,
                                f'{cased_shortform}_grounding_map.json'),
                   'w') as f:

--- a/deft_app/fix.py
+++ b/deft_app/fix.py
@@ -163,7 +163,7 @@ def submit():
     pos_labels_dict = {}
     for shortform, grounding_map in new_grounding_dict.items():
         cased_shortform = escape_filename(shortform)
-        with open(os.path.join(groundings_path, shortform,
+        with open(os.path.join(groundings_path, cased_shortform,
                                f'{cased_shortform}_names.json'), 'r') as f:
             temp = json.load(f)
         names_dict[shortform] = {transition[label]:
@@ -185,15 +185,15 @@ def submit():
     # update groundings files used for training model
     for shortform, grounding_map in new_grounding_dict.items():
         cased_shortform = escape_filename(shortform)
-        with open(os.path.join(groundings_path, shortform,
+        with open(os.path.join(groundings_path, cased_shortform,
                                f'{cased_shortform}_grounding_map.json'),
                   'w') as f:
             json.dump(grounding_map, f)
-        with open(os.path.join(groundings_path, shortform,
+        with open(os.path.join(groundings_path, cased_shortform,
                                f'{cased_shortform}_names.json'),
                   'w') as f:
             json.dump(names_dict[shortform], f)
-        with open(os.path.join(groundings_path, shortform,
+        with open(os.path.join(groundings_path, cased_shortform,
                                f'{cased_shortform}_pos_labels.json'),
                   'w') as f:
             json.dump(pos_labels_dict[shortform], f)

--- a/deft_app/ground.py
+++ b/deft_app/ground.py
@@ -7,7 +7,7 @@ from flask import Blueprint, request, render_template, session
 
 from .trips import trips_ground
 from .locations import DATA_PATH
-from .filenames import escape_lower_case
+from .filenames import escape_filename
 
 logger = logging.getLogger(__file__)
 
@@ -101,7 +101,7 @@ def generate_grounding_map():
                                                             names)
                  if grounding and name}
     groundings_path = os.path.join(DATA_PATH, 'groundings', shortform)
-    cased_shortform = escape_lower_case(shortform)
+    cased_shortform = escape_filename(shortform)
     try:
         os.mkdir(groundings_path)
     except FileExistsError:
@@ -137,7 +137,7 @@ def _init_with_trips(shortform, cutoff):
 def _init_from_file(shortform):
     longforms, scores = _load(shortform, 0)
     groundings_path = os.path.join(DATA_PATH, 'groundings', shortform)
-    cased_shortform = escape_lower_case(shortform)
+    cased_shortform = escape_filename(shortform)
     try:
         with open(os.path.join(groundings_path,
                                f'{cased_shortform}_grounding_map.json'),
@@ -162,7 +162,7 @@ def _init_from_file(shortform):
 
 
 def _load(shortform, cutoff):
-    cased_shortform = escape_lower_case(shortform)
+    cased_shortform = escape_filename(shortform)
     longforms_path = os.path.join(DATA_PATH, 'longforms',
                                   f'{cased_shortform}_longforms.json')
     try:

--- a/deft_app/ground.py
+++ b/deft_app/ground.py
@@ -7,7 +7,7 @@ from flask import Blueprint, request, render_template, session
 
 from .trips import trips_ground
 from .locations import DATA_PATH
-
+from .filenames import escape_lower_case
 
 logger = logging.getLogger(__file__)
 
@@ -101,18 +101,19 @@ def generate_grounding_map():
                                                             names)
                  if grounding and name}
     groundings_path = os.path.join(DATA_PATH, 'groundings', shortform)
+    cased_shortform = escape_lower_case(shortform)
     try:
         os.mkdir(groundings_path)
     except FileExistsError:
         pass
     with open(os.path.join(groundings_path,
-                           f'{shortform}_grounding_map.json'), 'w') as f:
+                           f'{cased_shortform}_grounding_map.json'), 'w') as f:
         json.dump(grounding_map, f)
     with open(os.path.join(groundings_path,
-                           f'{shortform}_names.json'), 'w') as f:
+                           f'{cased_shortform}_names.json'), 'w') as f:
         json.dump(names_map, f)
     with open(os.path.join(groundings_path,
-                           f'{shortform}_pos_labels.json'), 'w') as f:
+                           f'{cased_shortform}_pos_labels.json'), 'w') as f:
         json.dump(pos_labels, f)
     session.clear()
     return render_template('index.jinja2')
@@ -136,15 +137,18 @@ def _init_with_trips(shortform, cutoff):
 def _init_from_file(shortform):
     longforms, scores = _load(shortform, 0)
     groundings_path = os.path.join(DATA_PATH, 'groundings', shortform)
+    cased_shortform = escape_lower_case(shortform)
     try:
         with open(os.path.join(groundings_path,
-                               f'{shortform}_grounding_map.json'), 'r') as f:
+                               f'{cased_shortform}_grounding_map.json'),
+                  'r') as f:
             grounding_map = json.load(f)
         with open(os.path.join(groundings_path,
-                               f'{shortform}_names.json'), 'r') as f:
+                               f'{cased_shortform}_names.json'), 'r') as f:
             names = json.load(f)
         with open(os.path.join(groundings_path,
-                               f'{shortform}_pos_labels.json'), 'r') as f:
+                               f'{cased_shortform}_pos_labels.json'),
+                  'r') as f:
             pos_labels = json.load(f)
     except EnvironmentError:
         raise ValueError
@@ -158,8 +162,9 @@ def _init_from_file(shortform):
 
 
 def _load(shortform, cutoff):
+    cased_shortform = escape_lower_case(shortform)
     longforms_path = os.path.join(DATA_PATH, 'longforms',
-                                  f'{shortform}_longforms.json')
+                                  f'{cased_shortform}_longforms.json')
     try:
         with open(longforms_path, 'r') as f:
             scored_longforms = json.load(f)

--- a/deft_app/ground.py
+++ b/deft_app/ground.py
@@ -100,8 +100,8 @@ def generate_grounding_map():
     names_map = {grounding: name for grounding, name in zip(groundings,
                                                             names)
                  if grounding and name}
-    groundings_path = os.path.join(DATA_PATH, 'groundings', shortform)
     cased_shortform = escape_filename(shortform)
+    groundings_path = os.path.join(DATA_PATH, 'groundings', cased_shortform)
     try:
         os.mkdir(groundings_path)
     except FileExistsError:

--- a/deft_app/scripts/deft_mine.py
+++ b/deft_app/scripts/deft_mine.py
@@ -5,6 +5,7 @@ import argparse
 from deft.discover import DeftMiner
 
 from deft_app.locations import DATA_PATH
+from deft_app.file_names import escape_lower_case
 
 
 if __name__ == '__main__':
@@ -13,7 +14,8 @@ if __name__ == '__main__':
     parser.add_argument('vars', nargs='*')
     args = parser.parse_args()
     shortforms = args.vars
-    agg_name = ':'.join(sorted(shortforms))
+    agg_name = ':'.join(sorted([escape_lower_case(shortform)
+                                for shortform in shortforms]))
     texts_path = os.path.join(DATA_PATH, 'texts', agg_name,
                               f'{agg_name}_texts.json')
     with open(texts_path, 'r') as f:
@@ -24,11 +26,12 @@ if __name__ == '__main__':
         dm = DeftMiner(shortform)
         dm.process_texts(texts)
         longforms = dm.get_longforms()
+        escaped_shortform = escape_lower_case(shortform)
         out_path = os.path.join(DATA_PATH, 'longforms',
-                                f'{shortform}_longforms.json')
+                                f'{escaped_shortform}_longforms.json')
         with open(out_path, 'w') as f:
             json.dump(longforms, f)
         out_path = os.path.join(DATA_PATH, 'longforms',
-                                f'{shortform}_top.json')
+                                f'{escaped_shortform}_top.json')
         with open(out_path, 'w') as f:
             json.dump(dm.top(100), f)

--- a/deft_app/scripts/deft_mine.py
+++ b/deft_app/scripts/deft_mine.py
@@ -5,7 +5,7 @@ import argparse
 from deft.discover import DeftMiner
 
 from deft_app.locations import DATA_PATH
-from deft_app.filenames import escape_lower_case
+from deft_app.filenames import escape_filename
 
 
 if __name__ == '__main__':
@@ -14,7 +14,7 @@ if __name__ == '__main__':
     parser.add_argument('vars', nargs='*')
     args = parser.parse_args()
     shortforms = args.vars
-    agg_name = ':'.join(sorted([escape_lower_case(shortform)
+    agg_name = ':'.join(sorted([escape_filename(shortform)
                                 for shortform in shortforms]))
     texts_path = os.path.join(DATA_PATH, 'texts', agg_name,
                               f'{agg_name}_texts.json')
@@ -26,7 +26,7 @@ if __name__ == '__main__':
         dm = DeftMiner(shortform)
         dm.process_texts(texts)
         longforms = dm.get_longforms()
-        escaped_shortform = escape_lower_case(shortform)
+        escaped_shortform = escape_filename(shortform)
         out_path = os.path.join(DATA_PATH, 'longforms',
                                 f'{escaped_shortform}_longforms.json')
         with open(out_path, 'w') as f:

--- a/deft_app/scripts/deft_mine.py
+++ b/deft_app/scripts/deft_mine.py
@@ -5,7 +5,7 @@ import argparse
 from deft.discover import DeftMiner
 
 from deft_app.locations import DATA_PATH
-from deft_app.file_names import escape_lower_case
+from deft_app.filenames import escape_lower_case
 
 
 if __name__ == '__main__':

--- a/deft_app/scripts/get_agent_stmts.py
+++ b/deft_app/scripts/get_agent_stmts.py
@@ -24,6 +24,9 @@ if __name__ == '__main__':
     stmt_dict = get_stmts_with_agent_text_like(pattern,
                                                filter_genes=True)
     for shortform, stmts in stmt_dict.items():
+        if (shortform[0] in ['-', '.'] or
+                set(shortform) & set('*/:\\')):
+            continue
         cased_shortform = escape_filename(shortform)
         if re.match(keep, shortform):
             with open(os.path.join(DATA_PATH,

--- a/deft_app/scripts/get_agent_stmts.py
+++ b/deft_app/scripts/get_agent_stmts.py
@@ -7,7 +7,7 @@ import argparse
 from indra_db.util.content_scripts import get_stmts_with_agent_text_like
 
 from deft_app.locations import DATA_PATH
-
+from deft_app.file_names import escape_lower_case
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Get statements with agent'
@@ -24,7 +24,10 @@ if __name__ == '__main__':
     stmt_dict = get_stmts_with_agent_text_like(pattern,
                                                filter_genes=True)
     for shortform, stmts in stmt_dict.items():
+        cased_shortform = escape_lower_case(shortform)
         if re.match(keep, shortform):
-            with open(os.path.join(DATA_PATH, 'statements',
-                                   f'{shortform}_statements.json'), 'w') as f:
+            with open(os.path.join(DATA_PATH,
+                                   'statements',
+                                   f'{cased_shortform}_statements.json'),
+                      'w') as f:
                 json.dump(stmts, f)

--- a/deft_app/scripts/get_agent_stmts.py
+++ b/deft_app/scripts/get_agent_stmts.py
@@ -25,7 +25,7 @@ if __name__ == '__main__':
                                                filter_genes=True)
     for shortform, stmts in stmt_dict.items():
         if (shortform[0] in ['-', '.'] or
-                set(shortform) & set('*/:\\')):
+                set(shortform) & set(': ')):
             continue
         cased_shortform = escape_filename(shortform)
         if re.match(keep, shortform):

--- a/deft_app/scripts/get_agent_stmts.py
+++ b/deft_app/scripts/get_agent_stmts.py
@@ -7,7 +7,7 @@ import argparse
 from indra_db.util.content_scripts import get_stmts_with_agent_text_like
 
 from deft_app.locations import DATA_PATH
-from deft_app.file_names import escape_lower_case
+from deft_app.filenames import escape_lower_case
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Get statements with agent'

--- a/deft_app/scripts/get_agent_stmts.py
+++ b/deft_app/scripts/get_agent_stmts.py
@@ -7,7 +7,7 @@ import argparse
 from indra_db.util.content_scripts import get_stmts_with_agent_text_like
 
 from deft_app.locations import DATA_PATH
-from deft_app.filenames import escape_lower_case
+from deft_app.filenames import escape_filename
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Get statements with agent'
@@ -24,7 +24,7 @@ if __name__ == '__main__':
     stmt_dict = get_stmts_with_agent_text_like(pattern,
                                                filter_genes=True)
     for shortform, stmts in stmt_dict.items():
-        cased_shortform = escape_lower_case(shortform)
+        cased_shortform = escape_filename(shortform)
         if re.match(keep, shortform):
             with open(os.path.join(DATA_PATH,
                                    'statements',

--- a/deft_app/scripts/get_texts.py
+++ b/deft_app/scripts/get_texts.py
@@ -6,7 +6,7 @@ from indra.literature.deft_tools import universal_extract_text
 from indra_db.util.content_scripts import get_text_content_from_stmt_ids
 
 from deft_app.locations import DATA_PATH
-from deft_app.filenames import escape_lower_case
+from deft_app.filenames import escape_filename
 
 
 if __name__ == '__main__':
@@ -16,10 +16,10 @@ if __name__ == '__main__':
     args = parser.parse_args()
     shortforms = args.vars
     all_stmts = set()
-    cased_shortforms = [escape_lower_case(shortform) for shortform in
+    cased_shortforms = [escape_filename(shortform) for shortform in
                         sorted(shortforms)]
     for shortform in shortforms:
-        cased_shortform = escape_lower_case(shortform)
+        cased_shortform = escape_filename(shortform)
         path = os.path.join(DATA_PATH, 'statements',
                             f'{cased_shortform}_statements.json')
         with open(path, 'r') as f:

--- a/deft_app/scripts/get_texts.py
+++ b/deft_app/scripts/get_texts.py
@@ -16,10 +16,10 @@ if __name__ == '__main__':
     args = parser.parse_args()
     shortforms = args.vars
     all_stmts = set()
-    cased_shortforms = []
+    cased_shortforms = [escape_lower_case(shortform) for shortform in
+                        sorted(shortforms)]
     for shortform in shortforms:
         cased_shortform = escape_lower_case(shortform)
-        cased_shortforms.append(cased_shortform)
         path = os.path.join(DATA_PATH, 'statements',
                             f'{cased_shortform}_statements.json')
         with open(path, 'r') as f:
@@ -29,7 +29,7 @@ if __name__ == '__main__':
     text_dict = {text_ref: universal_extract_text(article,
                                                   contains=shortforms)
                  for text_ref, article in text_dict.items()}
-    agg_name = ':'.join(sorted(cased_shortforms))
+    agg_name = ':'.join(cased_shortforms)
     dir_path = os.path.join(DATA_PATH, 'texts', agg_name)
     if not os.path.exists(dir_path):
         os.makedirs(dir_path)

--- a/deft_app/scripts/get_texts.py
+++ b/deft_app/scripts/get_texts.py
@@ -6,6 +6,7 @@ from indra.literature.deft_tools import universal_extract_text
 from indra_db.util.content_scripts import get_text_content_from_stmt_ids
 
 from deft_app.locations import DATA_PATH
+from deft_app.file_names import escape_lower_case
 
 
 if __name__ == '__main__':
@@ -15,9 +16,12 @@ if __name__ == '__main__':
     args = parser.parse_args()
     shortforms = args.vars
     all_stmts = set()
+    cased_shortforms = []
     for shortform in shortforms:
+        cased_shortform = escape_lower_case(shortform)
+        cased_shortforms.append(cased_shortform)
         path = os.path.join(DATA_PATH, 'statements',
-                            f'{shortform}_statements.json')
+                            f'{cased_shortform}_statements.json')
         with open(path, 'r') as f:
             stmts = json.load(f)
         all_stmts.update(stmts)
@@ -25,7 +29,7 @@ if __name__ == '__main__':
     text_dict = {text_ref: universal_extract_text(article,
                                                   contains=shortforms)
                  for text_ref, article in text_dict.items()}
-    agg_name = ':'.join(sorted(shortforms))
+    agg_name = ':'.join(sorted(cased_shortforms))
     dir_path = os.path.join(DATA_PATH, 'texts', agg_name)
     if not os.path.exists(dir_path):
         os.makedirs(dir_path)

--- a/deft_app/scripts/get_texts.py
+++ b/deft_app/scripts/get_texts.py
@@ -6,7 +6,7 @@ from indra.literature.deft_tools import universal_extract_text
 from indra_db.util.content_scripts import get_text_content_from_stmt_ids
 
 from deft_app.locations import DATA_PATH
-from deft_app.file_names import escape_lower_case
+from deft_app.filenames import escape_lower_case
 
 
 if __name__ == '__main__':

--- a/deft_app/scripts/model.py
+++ b/deft_app/scripts/model.py
@@ -12,6 +12,7 @@ from deft.modeling.classify import DeftClassifier
 from deft.modeling.corpora import DeftCorpusBuilder
 
 from deft_app.locations import DATA_PATH
+from deft_app.filenames import escape_lower_case
 from deft_app.scripts.consistency import check_grounding_dict, \
     check_consistency_grounding_dict_pos_labels
 
@@ -45,9 +46,12 @@ def train(shortforms, additional=None, n_jobs=1):
         raise RuntimeError('Inconsistent grounding maps for shortforms.')
     pos_labels = sorted(pos_labels)
 
+    cased_shortforms = [escape_lower_case(shortform)
+                        for shortform in sorted(shortforms)]
+
     # model name is built up from shortforms in model
     # (most models only have one shortform)
-    agg_name = ':'.join(sorted(shortforms))
+    agg_name = ':'.join(cased_shortforms)
     with open(os.path.join(texts_path, agg_name,
                            f'{agg_name}_texts.json'), 'r') as f:
         text_dict = json.load(f)

--- a/deft_app/scripts/model.py
+++ b/deft_app/scripts/model.py
@@ -31,15 +31,18 @@ def train(shortforms, additional=None, n_jobs=1):
     pos_labels = set()
     # combine grounding maps and names from multiple shortforms into one model
     for shortform in shortforms:
-        with open(os.path.join(groundings_path, shortform,
-                               f'{shortform}_grounding_map.json'), 'r') as f:
+        cased_shortform = escape_filename(shortform)
+        with open(os.path.join(groundings_path, cased_shortform,
+                               f'{cased_shortform}_grounding_map.json'),
+                  'r') as f:
             grounding_map = json.load(f)
             grounding_dict[shortform] = grounding_map
-        with open(os.path.join(groundings_path, shortform,
-                               f'{shortform}_names.json'), 'r') as f:
+        with open(os.path.join(groundings_path, cased_shortform,
+                               f'{cased_shortform}_names.json'), 'r') as f:
             names.update(json.load(f))
-        with open(os.path.join(groundings_path, shortform,
-                               f'{shortform}_pos_labels.json'), 'r') as f:
+        with open(os.path.join(groundings_path, cased_shortform,
+                               f'{cased_shortform}_pos_labels.json'),
+                  'r') as f:
             pos_labels.update(json.load(f))
 
     if not check_grounding_dict(grounding_dict):

--- a/deft_app/scripts/model.py
+++ b/deft_app/scripts/model.py
@@ -12,7 +12,7 @@ from deft.modeling.classify import DeftClassifier
 from deft.modeling.corpora import DeftCorpusBuilder
 
 from deft_app.locations import DATA_PATH
-from deft_app.filenames import escape_lower_case
+from deft_app.filenames import escape_filename
 from deft_app.scripts.consistency import check_grounding_dict, \
     check_consistency_grounding_dict_pos_labels
 
@@ -46,7 +46,7 @@ def train(shortforms, additional=None, n_jobs=1):
         raise RuntimeError('Inconsistent grounding maps for shortforms.')
     pos_labels = sorted(pos_labels)
 
-    cased_shortforms = [escape_lower_case(shortform)
+    cased_shortforms = [escape_filename(shortform)
                         for shortform in sorted(shortforms)]
 
     # model name is built up from shortforms in model

--- a/deft_app/scripts/model_to_s3.py
+++ b/deft_app/scripts/model_to_s3.py
@@ -7,11 +7,11 @@ import tempfile
 from deft.download import get_s3_models
 
 from deft_app.locations import DATA_PATH, S3_BUCKET
-from deft_app.filenames import escape_lower_case
+from deft_app.filenames import escape_filename
 
 
 def model_to_s3(model_name):
-    model_name = escape_lower_case(model_name)
+    model_name = escape_filename(model_name)
     local_models_path = os.path.join(DATA_PATH, 'models', model_name)
     with open(os.path.join(local_models_path,
                            f'{model_name}_grounding_dict.json')) as f:

--- a/deft_app/scripts/model_to_s3.py
+++ b/deft_app/scripts/model_to_s3.py
@@ -7,9 +7,11 @@ import tempfile
 from deft.download import get_s3_models
 
 from deft_app.locations import DATA_PATH, S3_BUCKET
+from deft_app.filenames import escape_lower_case
 
 
 def model_to_s3(model_name):
+    model_name = escape_lower_case(model_name)
     local_models_path = os.path.join(DATA_PATH, 'models', model_name)
     with open(os.path.join(local_models_path,
                            f'{model_name}_grounding_dict.json')) as f:

--- a/deft_app/templates/fix.jinja2
+++ b/deft_app/templates/fix.jinja2
@@ -52,7 +52,7 @@
     <table>
       <tr>
 	<th>
-	  Positive Labels
+	  Labels
 	</th>
       </tr>
       {% for label in labels %}

--- a/deft_app/templates/input.jinja2
+++ b/deft_app/templates/input.jinja2
@@ -34,7 +34,7 @@
 	  <td class="pad blank">
 	  </td>
 	  <td class="labels-head">
-	    Positive Labels
+	    Labels
 	  </td>
 	</th>
 	{% for longform, score, name, grounding, label in data %}

--- a/deft_app/trips.py
+++ b/deft_app/trips.py
@@ -60,7 +60,7 @@ def _trips_ground(agent_text):
     elif go_id is not None:
         grounding = 'GO:' + go_id
     elif chebi_id is not None:
-        grounding = chebi_id
+        grounding = 'CHEBI:' + chebi_id
     elif mesh_id is not None:
         grounding = 'MESH:' + mesh_id
     elif up_id is not None:

--- a/deft_app/trips.py
+++ b/deft_app/trips.py
@@ -66,8 +66,8 @@ def _trips_ground(agent_text):
     else:
         grounding = None
 
-    if grounding is not None:
-        name = agent.name
+    # only set name if grounding exists
+    name = agent.name if grounding is not None else None
 
     return name, grounding
 

--- a/deft_app/trips.py
+++ b/deft_app/trips.py
@@ -68,6 +68,9 @@ def _trips_ground(agent_text):
     else:
         grounding = None
 
+    if grounding is not None:
+        name = agent.name
+
     return name, grounding
 
 

--- a/deft_app/trips.py
+++ b/deft_app/trips.py
@@ -41,8 +41,6 @@ def _trips_ground(agent_text):
     else:
         return None, None
 
-    name = agent.name
-
     hgnc_id = agent.db_refs.get('HGNC')
     fplx_id = agent.db_refs.get('FPLX')
     up_id = agent.db_refs.get('UP')


### PR DESCRIPTION
This PR adds escape characters to lower case characters and the forward slash within shortforms. This allows the hack of storing data in the file system with directories keyed on shortform to work on case insensitive file systems and when shortforms contain a forward slash. Surpisingly the latter actually exist. I/R for instance commonly stands for ischemia-reperfusion and may or may not be ambiguous. A few fixes have also been made to trips grounding. GO and CHEBI ids now appear prefixed by GO and CHEBI, GO:XXXXXX instead of XXXXXX for instance. Trips grounding is also now changed so that an longform has its corresponding agent name populated only if a grounding is also found.